### PR TITLE
🔧 FIX: Align pnpm version between workflow and package.json

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup pnpm
       uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
       with:
-        version: 8
+        version: 10.4.1
         
     - name: Setup Node.js
       uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v4.0.0
@@ -43,6 +43,7 @@ jobs:
         pnpm --version
         echo "pnpm location:"
         which pnpm
+        echo "Expected version: 10.4.1"
         
     - name: Security Audit
       run: |


### PR DESCRIPTION
- Update pnpm version from 8 to 10.4.1 in GitHub Actions workflow
- Match version specified in package.json packageManager field
- Add version verification step for debugging
- Resolve version conflict causing deployment failures

Fixes: Multiple pnpm versions specified error
Before: workflow=8, package.json=10.4.1 (conflict)
After: workflow=10.4.1, package.json=10.4.1 (aligned)
Impact: Deploy workflow should now pass successfully