### PR TITLE
fix: align API integration with local backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Uma ferramenta web especializada para screening automatizado da estratégia "The
 
 O **The Wheel Screener** é uma aplicação web desenvolvida como parte de um projeto aplicado de pós-graduação em Ciência de Dados e Mercado Financeiro. A ferramenta automatiza o processo de identificação de oportunidades para a estratégia "The Wheel", reduzindo o tempo de análise de 2 horas para 10 minutos (92% de redução).
 
+## 📌 Objetivos e Requisitos do Sistema
+
+- Integrar-se à API da OpLab para instrumentos, cotações, fundamentos e screening.
+- Utilizar dados do Yahoo Finance como fallback automático para cotações e históricos.
+- Fornecer interface web responsiva com autenticação simples e configuração segura de token.
+- Disponibilizar backend Flask em `/api` para servir e processar dados.
+- Garantir respostas em até 10 minutos com atualização periódica configurável.
+
 ### 🌐 Demo Online
 **URL:** https://pdro-dev.github.io/the-wheel-screener/
 

--- a/docs/API_INTEGRATION.md
+++ b/docs/API_INTEGRATION.md
@@ -13,13 +13,13 @@ A camada principal que gerencia todas as comunicações com a API OpLab.
 #### Configuração
 ```javascript
 export const API_CONFIG = {
-  baseURL: '/api',
+  baseURL: import.meta?.env?.VITE_OPLAB_API_URL || '/api',
   timeout: 30000,
   retryAttempts: 3,
   retryDelay: 1000,
-  cache: {
+  refreshIntervals: {
     instruments: 5 * 60 * 1000,    // 5 minutos
-    quotes: 30 * 1000,             // 30 segundos  
+    quotes: 30 * 1000,             // 30 segundos
     fundamentals: 10 * 60 * 1000,  // 10 minutos
     screening: 2 * 60 * 1000       // 2 minutos
   }

--- a/src/__tests__/opLabAPI.test.js
+++ b/src/__tests__/opLabAPI.test.js
@@ -68,7 +68,7 @@ describe('OpLabAPIService', () => {
       const key = 'test-key'
       const data = { result: 'test' }
       
-      service.setCache(key, data, '/market/instruments')
+      service.setCache(key, data, API_ENDPOINTS.instruments)
       const cached = service.getFromCache(key)
       
       expect(cached).toEqual(data)
@@ -78,7 +78,7 @@ describe('OpLabAPIService', () => {
       const key = 'test-key'
       const data = { result: 'test' }
       
-      service.setCache(key, data, '/market/instruments')
+      service.setCache(key, data, API_ENDPOINTS.instruments)
       
       // Fast forward time beyond cache TTL
       vi.advanceTimersByTime(API_CONFIG.refreshIntervals.instruments + 1000)
@@ -112,7 +112,7 @@ describe('OpLabAPIService', () => {
       const key = 'dynamic-key'
       const data = { result: 'dynamic' }
 
-      service.setCache(key, data, '/market/instruments')
+      service.setCache(key, data, API_ENDPOINTS.instruments)
       vi.advanceTimersByTime(1000 + 10)
 
       expect(service.getFromCache(key)).toBeNull()
@@ -225,7 +225,7 @@ describe('OpLabAPIService', () => {
 
       expect(result).toEqual(mockData)
       expect(mockFetch).toHaveBeenCalledWith(
-        '/api/market/instruments',
+        '/api/instruments',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ sector: 'Oil' })
@@ -244,7 +244,7 @@ describe('OpLabAPIService', () => {
 
       expect(result).toEqual(mockData)
       expect(mockFetch).toHaveBeenCalledWith(
-        '/api/market/quote',
+        '/api/quotes',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ symbols: ['PETR4', 'VALE3'] })
@@ -262,7 +262,7 @@ describe('OpLabAPIService', () => {
       const result = await service.getFundamentals('PETR4')
 
       expect(result).toEqual(mockData)
-      expect(mockFetch).toHaveBeenCalledWith('/api/market/fundamentals/PETR4', expect.any(Object))
+      expect(mockFetch).toHaveBeenCalledWith('/api/fundamentals/PETR4', expect.any(Object))
     })
 
     it('should check health', async () => {

--- a/src/hooks/useOpLabAPI.js
+++ b/src/hooks/useOpLabAPI.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 
 // Base URL for OpLab API (can be overridden via environment variable)
-const API_BASE_URL = import.meta.env.VITE_OPLAB_API_URL || 'https://api.oplab.com.br/v3'
+const API_BASE_URL = import.meta.env.VITE_OPLAB_API_URL || '/api'
 
 // Basic in-memory users for simple authentication
 const VALID_USERS = {
@@ -316,43 +316,13 @@ export function useWheelScreening() {
     setResults([])
 
     try {
-      // Step 1: Get instruments (25% progress)
-      setProgress(25)
-      const instruments = await api.makeRequest('/screening/instruments', {
+      setProgress(50)
+      const { results: screeningResults } = await api.makeRequest('/screening', {
         method: 'POST',
         body: JSON.stringify(filters)
       })
 
-      // Step 2: Get quotes for filtered instruments (50% progress)
-      setProgress(50)
-      const quotes = await api.makeRequest('/screening/quotes', {
-        method: 'POST',
-        body: JSON.stringify({ 
-          symbols: instruments.map(i => i.symbol)
-        })
-      })
-
-      // Step 3: Get fundamentals for candidates (75% progress)
-      setProgress(75)
-      const fundamentals = await api.makeRequest('/screening/fundamentals', {
-        method: 'POST',
-        body: JSON.stringify({ 
-          symbols: quotes.filter(q => q.volume >= filters.minVolume).map(q => q.symbol)
-        })
-      })
-
-      // Step 4: Calculate wheel scores (100% progress)
       setProgress(100)
-      const screeningResults = await api.makeRequest('/screening/wheel', {
-        method: 'POST',
-        body: JSON.stringify({
-          instruments,
-          quotes,
-          fundamentals,
-          filters
-        })
-      })
-
       setResults(screeningResults)
       return screeningResults
 

--- a/src/services/opLabAPI.js
+++ b/src/services/opLabAPI.js
@@ -2,8 +2,8 @@
 
 // API Configuration
 export const API_CONFIG = {
-  // Base URL now defaults to the official OpLab API but can be overridden
-  baseURL: import.meta?.env?.VITE_OPLAB_API_URL || 'https://api.oplab.com.br/v3',
+  // Base URL now defaults to local proxy but can be overridden for production
+  baseURL: import.meta?.env?.VITE_OPLAB_API_URL || '/api',
   timeout: 30000,
   retryAttempts: 3,
   retryDelay: 1000,
@@ -19,11 +19,11 @@ export const API_CONFIG = {
 }
 
 export const API_ENDPOINTS = {
-  instruments: '/market/instruments',
-  quotes: '/market/quote',
-  fundamentals: '/market/fundamentals',
-  options: '/market/options',
-  screening: '/market/screening',
+  instruments: '/instruments',
+  quotes: '/quotes',
+  fundamentals: '/fundamentals',
+  options: '/options',
+  screening: '/screening',
   user: '/user',
   health: '/health'
 }


### PR DESCRIPTION
## Summary
- default OpLab API base URL to `/api` and update endpoints
- simplify wheel screening hook to use backend `/screening` route
- document local proxy configuration and system requirements

## Testing
- `npm test` *(fails: Invalid Chai property: toBeInTheDocument)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bee5d4dc8329bee5a14321362621