### PR TITLE
Handle wrapped instruments and quotes

### DIFF
--- a/src/__tests__/opLabAPI.test.js
+++ b/src/__tests__/opLabAPI.test.js
@@ -218,7 +218,7 @@ describe('OpLabAPIService', () => {
       const mockData = [{ symbol: 'PETR4', name: 'Petrobras' }]
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockData)
+        json: () => Promise.resolve({ instruments: mockData })
       })
 
       const result = await service.getInstruments({ sector: 'Oil' })
@@ -237,7 +237,7 @@ describe('OpLabAPIService', () => {
       const mockData = [{ symbol: 'PETR4', price: 32.45 }]
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockData)
+        json: () => Promise.resolve({ quotes: mockData })
       })
 
       const result = await service.getQuotes(['PETR4', 'VALE3'])
@@ -256,7 +256,7 @@ describe('OpLabAPIService', () => {
       const mockData = { symbol: 'PETR4', roic: 8.2 }
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockData)
+        json: () => Promise.resolve({ fundamentals: mockData })
       })
 
       const result = await service.getFundamentals('PETR4')
@@ -301,22 +301,25 @@ describe('OpLabAPIService', () => {
       const mockQuotes = [
         { symbol: 'PETR4', price: 32.45, volume: 1000000 }
       ]
-      const mockFundamentals = [
-        { symbol: 'PETR4', roic: 8.2, roe: 12, debtToEquity: 0.4 }
-      ]
+      const mockFundamental = {
+        symbol: 'PETR4',
+        roic: 8.2,
+        roe: 12,
+        debtToEquity: 0.4
+      }
 
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve(mockInstruments)
+          json: () => Promise.resolve({ instruments: mockInstruments })
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve(mockQuotes)
+          json: () => Promise.resolve({ quotes: mockQuotes })
         })
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve(mockFundamentals)
+          json: () => Promise.resolve({ fundamentals: mockFundamental })
         })
 
       const filters = {
@@ -339,7 +342,7 @@ describe('OpLabAPIService', () => {
       vi.useRealTimers()
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve([])
+        json: () => Promise.resolve({ instruments: [] })
       })
 
       const result = await service.performWheelScreening({})
@@ -369,7 +372,10 @@ describe('OpLabAPIService', () => {
         fundamental: { roic: 15, roe: 18, debtToEquity: 0.3, revenueGrowth: 0.15 }
       }
 
-      const score = service.calculateWheelScore(stock, { minVolume: 100000 })
+      const score = service.calculateWheelScore({
+        ...stock,
+        filters: { minVolume: 100000 }
+      })
 
       expect(score).toBeGreaterThan(50)
       expect(score).toBeLessThanOrEqual(100)
@@ -382,7 +388,10 @@ describe('OpLabAPIService', () => {
         fundamental: {}
       }
 
-      const score = service.calculateWheelScore(stock, { minVolume: 100000 })
+      const score = service.calculateWheelScore({
+        ...stock,
+        filters: { minVolume: 100000 }
+      })
 
       expect(score).toBeGreaterThan(0)
       expect(score).toBeLessThanOrEqual(100)

--- a/src/hooks/useOpLabAPI.js
+++ b/src/hooks/useOpLabAPI.js
@@ -260,21 +260,24 @@ export function useOpLabService() {
   const api = useOpLabAPI()
 
   const getInstruments = useCallback(async (filters = {}) => {
-    return api.makeRequest('/instruments', {
+    const data = await api.makeRequest('/instruments', {
       method: 'POST',
       body: JSON.stringify(filters)
     })
+    return data?.instruments ?? data
   }, [api])
 
   const getQuotes = useCallback(async (symbols) => {
-    return api.makeRequest('/quotes', {
+    const data = await api.makeRequest('/quotes', {
       method: 'POST',
       body: JSON.stringify({ symbols })
     })
+    return data?.quotes ?? data
   }, [api])
 
   const getFundamentals = useCallback(async (symbol) => {
-    return api.makeRequest(`/fundamentals/${symbol}`)
+    const data = await api.makeRequest(`/fundamentals/${symbol}`)
+    return data?.fundamentals ?? data
   }, [api])
 
   const getOptions = useCallback(async (symbol, filters = {}) => {
@@ -395,7 +398,7 @@ export function useInstruments(filters = {}) {
         method: 'POST',
         body: JSON.stringify(filters)
       })
-      setInstruments(data)
+      setInstruments(data?.instruments ?? data)
     } catch (err) {
       setError(err.message)
       setInstruments([])
@@ -444,7 +447,7 @@ export function useQuotes(symbols = []) {
         method: 'POST',
         body: JSON.stringify({ symbols })
       })
-      setQuotes(data)
+      setQuotes(data?.quotes ?? data)
     } catch (err) {
       setError(err.message)
       setQuotes([])
@@ -490,7 +493,7 @@ export function useFundamentals(symbol) {
 
     try {
       const data = await api.makeRequest(`/fundamentals/${symbol}`)
-      setFundamentals(data)
+      setFundamentals(data?.fundamentals ?? data)
     } catch (err) {
       setError(err.message)
       setFundamentals(null)

--- a/src/services/opLabAPI.js
+++ b/src/services/opLabAPI.js
@@ -230,21 +230,24 @@ export class OpLabAPIService {
 
   // API Methods
   async getInstruments(filters = {}) {
-    return this.makeRequest(API_ENDPOINTS.instruments, {
+    const data = await this.makeRequest(API_ENDPOINTS.instruments, {
       method: 'POST',
       body: JSON.stringify(filters)
     })
+    return data?.instruments ?? data
   }
 
   async getQuotes(symbols) {
-    return this.makeRequest(API_ENDPOINTS.quotes, {
+    const data = await this.makeRequest(API_ENDPOINTS.quotes, {
       method: 'POST',
       body: JSON.stringify({ symbols })
     })
+    return data?.quotes ?? data
   }
 
   async getFundamentals(symbol) {
-    return this.makeRequest(`${API_ENDPOINTS.fundamentals}/${symbol}`)
+    const data = await this.makeRequest(`${API_ENDPOINTS.fundamentals}/${symbol}`)
+    return data?.fundamentals ?? data
   }
 
   async getOptions(symbol, filters = {}) {


### PR DESCRIPTION
## Summary
- unwrap instruments, quotes and fundamentals arrays from OpLab API responses
- update React hooks to consume data.instruments, data.quotes and data.fundamentals
- adjust opLabAPI tests for new response structure and wheel score helper

## Testing
- `npx vitest run src/__tests__/opLabAPI.test.js` *(fails: Timers are not mocked, Cannot add property defaultService, Test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b8463be083298e129e547d8f8dd1