### PR TITLE
Add backend and frontend tests with pytest configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,3 +353,21 @@ Este projeto está sob a licença MIT. Veja o arquivo [LICENSE](LICENSE) para ma
 
 *Desenvolvido com ❤️ e 🔒 segurança para a comunidade de investidores brasileiros*
 
+
+## 🧪 Testes
+
+### Backend
+1. Instale as dependências mínimas:
+   ```bash
+   pip install -r backend-oplab/requirements.txt
+   ```
+2. Execute os testes com `pytest` (configurado via `pytest.ini`):
+   ```bash
+   pytest
+   ```
+
+### Frontend
+Execute os testes do frontend usando Vitest:
+```bash
+pnpm test
+```

--- a/backend-oplab/tests/test_oplab_routes.py
+++ b/backend-oplab/tests/test_oplab_routes.py
@@ -1,0 +1,81 @@
+import os
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+# Ensure src package is importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from main import app  # noqa: E402
+from routes.oplab import MockDataGenerator  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_health_endpoint(client):
+    response = client.get('/api/health')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['status'] == 'healthy'
+    assert '/api/quotes' in data['endpoints']
+
+
+def test_instruments_endpoint(client):
+    response = client.post('/api/instruments', json={})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert 'instruments' in data
+    assert data['total'] == len(data['instruments'])
+    assert len(data['instruments']) > 0
+
+
+def test_quotes_endpoint(client):
+    symbol = 'ITUB4.SA'
+    response = client.post('/api/quotes', json={'symbols': [symbol]})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data['quotes']) == 1
+    assert data['quotes'][0]['symbol'] == symbol
+
+
+def test_fundamentals_endpoint(client):
+    symbol = 'ITUB4.SA'
+    response = client.get(f'/api/fundamentals/{symbol}')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['fundamentals']['symbol'] == symbol
+
+
+@patch('yfinance.Ticker')
+def test_get_real_stock_data_real(MockTicker):
+    mock_hist = pd.DataFrame({'Close': [10.0, 11.0], 'Volume': [1000, 2000]})
+    instance = MockTicker.return_value
+    instance.history.return_value = mock_hist
+
+    gen = MockDataGenerator()
+    result = gen.get_real_stock_data('ITUB4.SA')
+
+    assert result['dataSource'] == 'real'
+    assert result['price'] == 11.0
+    assert result['volume'] == 2000
+    assert result['historicalPrices'] == [10.0, 11.0]
+
+
+@patch('yfinance.Ticker')
+def test_get_real_stock_data_mock(MockTicker):
+    instance = MockTicker.return_value
+    instance.history.side_effect = Exception('fail')
+
+    gen = MockDataGenerator()
+    result = gen.get_real_stock_data('ITUB4.SA')
+
+    assert result['dataSource'] == 'mock'
+    assert 'price' in result and 'volume' in result
+    assert len(result['historicalPrices']) == 252

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+addopts = -q
+testpaths =
+    backend-oplab/tests
+pythonpath =
+    backend-oplab/src

--- a/src/__tests__/errorHandling.test.js
+++ b/src/__tests__/errorHandling.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { OpLabAPIService, OpLabAPIError, API_CONFIG } from '../opLabAPI'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe('OpLabAPIService error handling', () => {
+  let service
+
+  beforeEach(() => {
+    API_CONFIG.baseURL = '/api'
+    service = new OpLabAPIService('token')
+    mockFetch.mockReset()
+  })
+
+  it('throws OpLabAPIError on network failure', async () => {
+    const error = OpLabAPIError.networkError('fail')
+    mockFetch.mockRejectedValueOnce(error)
+    await expect(
+      service.executeRequest({ endpoint: '/test', options: { method: 'GET' } })
+    ).rejects.toBe(error)
+  })
+
+  it('throws error on invalid JSON format', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new Error('Bad JSON'))
+    })
+    await expect(
+      service.executeRequest({ endpoint: '/test', options: { method: 'GET' } })
+    ).rejects.toBeInstanceOf(Error)
+  })
+})


### PR DESCRIPTION
## Summary
- add Flask route and data generator tests
- add vitest error handling test
- document test execution and add pytest.ini

## Testing
- `pytest`
- `pnpm test` *(fails: Invalid Chai property toBeInTheDocument, etc.)*
- `pnpm test run src/__tests__/errorHandling.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4b86bfad8832989c2a6d85dc275e9