### PR TITLE
feat: add structured logging and metrics

### DIFF
--- a/backend-oplab/src/main.py
+++ b/backend-oplab/src/main.py
@@ -3,11 +3,15 @@ import sys
 # DON'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from flask import Flask, send_from_directory
+import json
+import time
+import logging
+from flask import Flask, send_from_directory, request, g
 from flask_cors import CORS
 from src.models.user import db
+from src.models.audit import AuditLog
 from src.routes.user import user_bp
-from src.routes.oplab import oplab_bp
+from src.routes.oplab import oplab_bp, metrics
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
@@ -24,6 +28,54 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
 with app.app_context():
     db.create_all()
+
+
+logger = logging.getLogger("oplab")
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+
+@app.before_request
+def start_request():
+    if request.path.startswith('/api'):
+        g.start_time = time.time()
+        g.cache_hits_before = metrics['cache_hits']
+
+
+@app.after_request
+def log_request(response):
+    if request.path.startswith('/api') and hasattr(g, 'start_time'):
+        duration = time.time() - g.start_time
+        cache_hits = metrics['cache_hits'] - g.cache_hits_before
+        metrics['requests'] += 1
+        metrics['total_response_time'] += duration
+        error_msg = None
+        if response.status_code >= 400:
+            try:
+                error_msg = response.get_json().get('error')
+            except Exception:
+                pass
+        log_entry = {
+            'event': 'request',
+            'endpoint': request.path,
+            'duration': duration,
+            'cache_hits': cache_hits,
+            'status': response.status_code
+        }
+        if error_msg:
+            log_entry['error'] = error_msg
+        logger.info(json.dumps(log_entry))
+        audit = AuditLog(endpoint=request.path,
+                         response_time=duration,
+                         cache_hits=cache_hits,
+                         status=response.status_code,
+                         error=error_msg)
+        db.session.add(audit)
+        db.session.commit()
+    return response
 
 @app.route('/', defaults={'path': ''})
 @app.route('/<path:path>')

--- a/backend-oplab/src/models/audit.py
+++ b/backend-oplab/src/models/audit.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from .user import db
+
+class AuditLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    endpoint = db.Column(db.String(255), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    response_time = db.Column(db.Float)
+    cache_hits = db.Column(db.Integer)
+    status = db.Column(db.Integer)
+    error = db.Column(db.String(255))
+
+    def __repr__(self):
+        return f"<AuditLog {self.endpoint} {self.timestamp}>"


### PR DESCRIPTION
## Summary
- add AuditLog model for storing request statistics
- instrument Flask app with structured logging and request metrics
- add cache-aware stock data retrieval and /api/metrics endpoint

## Testing
- `python -m py_compile backend-oplab/src/main.py backend-oplab/src/routes/oplab.py backend-oplab/src/models/audit.py`
- `pytest backend-oplab/src -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b871569c83299338e4e0b06d0f14