### PR TITLE
Configure Vitest setup and fix SQLite initialization

### DIFF
--- a/backend-oplab/src/main.py
+++ b/backend-oplab/src/main.py
@@ -25,7 +25,10 @@ app.register_blueprint(oplab_bp)
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 if not DATABASE_URL:
-    DATABASE_URL = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'database', 'app.db')}"
+    # Ensure the SQLite directory exists before constructing the database URL
+    db_dir = os.path.join(os.path.dirname(__file__), 'database')
+    os.makedirs(db_dir, exist_ok=True)
+    DATABASE_URL = f"sqlite:///{os.path.join(db_dir, 'app.db')}"
 app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)

--- a/backend-oplab/src/models/fundamental.py
+++ b/backend-oplab/src/models/fundamental.py
@@ -15,6 +15,7 @@ class Fundamental(db.Model):
 
     def to_dict(self):
         return {
+            'symbol': self.instrument.symbol if getattr(self, 'instrument', None) else None,
             'roic': self.roic,
             'roe': self.roe,
             'debtToEquity': self.debt_to_equity,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    globals: true
+    globals: true,
+    setupFiles: 'src/test/setup.js'
   }
 })


### PR DESCRIPTION
## Summary
- load shared Vitest setup file so custom matchers like `toBeInTheDocument` are available
- ensure SQLite database directory exists and expose symbol in fundamentals API

## Testing
- `pnpm test` *(fails: 5 failed, 4 passed, 1 skipped)*
- `pytest`
- `pnpm dev`
- `python backend-oplab/src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4ccfb4f80832991d4f12703896e31