### PR TITLE
ci: install pytest in integration tests workflow

### DIFF
--- a/.github/workflows/test-oplab-integration.yml
+++ b/.github/workflows/test-oplab-integration.yml
@@ -1,0 +1,28 @@
+name: Test OPLab Integration
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend-oplab/requirements.txt pytest
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- install backend dependencies and pytest before running CI tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a55238f9388329affbf57a69f8d30c