### PR TITLE
refactor: set OPLAB token env at job level

### DIFF
--- a/.github/workflows/test-oplab-integration.yml
+++ b/.github/workflows/test-oplab-integration.yml
@@ -114,7 +114,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: desenvolvimento
     needs: [test-backend, test-frontend]
-
     env:
       OPLAB_API_TOKEN: ${{ secrets.OPLAB_API_TOKEN }}
 

--- a/.github/workflows/test-oplab-integration.yml
+++ b/.github/workflows/test-oplab-integration.yml
@@ -16,6 +16,8 @@ jobs:
   test-backend:
     runs-on: ubuntu-latest
     environment: desenvolvimento  # Environment name configured in GitHub
+    env:
+      OPLAB_API_TOKEN: ${{ secrets.OPLAB_API_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -34,8 +36,6 @@ jobs:
           pip install -r requirements.txt
 
       - name: Test OpLab API Integration
-        env:
-          OPLAB_API_TOKEN: ${{ secrets.OPLAB_API_TOKEN }}
         run: |
           cd backend-oplab
           echo "Testing OpLab API integration with token..."
@@ -72,8 +72,6 @@ jobs:
           "
 
       - name: Run Backend Server Test
-        env:
-          OPLAB_API_TOKEN: ${{ secrets.OPLAB_API_TOKEN }}
         run: |
           cd backend-oplab
           timeout 30s python src/main.py &
@@ -116,7 +114,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: desenvolvimento
     needs: [test-backend, test-frontend]
-    
+
+    env:
+      OPLAB_API_TOKEN: ${{ secrets.OPLAB_API_TOKEN }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -137,8 +138,6 @@ jobs:
           npm ci
 
       - name: Run integration tests
-        env:
-          OPLAB_API_TOKEN: ${{ secrets.OPLAB_API_TOKEN }}
         run: |
           echo "🚀 Starting integration tests..."
           


### PR DESCRIPTION
## Summary
- Expose OPLAB_API_TOKEN secret for backend and integration-test jobs in test-oplab-integration workflow

## Testing
- `npm test` *(fails: 7 failed tests)*
- `pytest` *(fails: syntax error during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a56075391083299600f7a82720e403