### PR TITLE
fix: ensure consistent hooks on auth change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -149,11 +149,6 @@ function App() {
   const debouncedSearch = useDebounce(filters.search, 300)
   const { cachedResults, setCachedResults } = useResultCache()
 
-  // Login component
-  if (!isAuthenticated) {
-    return <Login />
-  }
-
   // Main navigation tabs - different for user vs admin
   const getMainTabs = () => {
     const baseTabs = [
@@ -252,6 +247,11 @@ function App() {
 
   const mainTabs = getMainTabs()
   const adminDropdownItems = getAdminDropdownItems()
+
+  // Render login when user is not authenticated
+  if (!isAuthenticated) {
+    return <Login />
+  }
 
   return (
     <ErrorBoundary>


### PR DESCRIPTION
## Summary
- maintain hook order by moving login check after hook declarations

## Testing
- `npm run lint` *(fails: 'vi' is not defined)*
- `npm test -- --run` *(fails: Cannot find module '@/hooks/usePerformance')*


------
https://chatgpt.com/codex/tasks/task_e_68a5657be2b883299e7a2eac51cad64c