### PR TITLE
fix: update OpLab API base URL and tests

### DIFF
--- a/backend-oplab/src/routes/oplab.py
+++ b/backend-oplab/src/routes/oplab.py
@@ -32,7 +32,7 @@ metrics = {
 # OpLab API Client for real integration
 class OpLabAPIClient:
     def __init__(self):
-        self.base_url = "https://api.oplab.com.br/v1"
+        self.base_url = "https://api.oplab.com.br/v3"
         self.token = os.getenv('OPLAB_API_TOKEN')
         self.session = requests.Session()
         
@@ -722,7 +722,8 @@ def get_fundamentals(symbol):
             'timestamp': datetime.now().isoformat(),
             'dataSource': 'mock'
         }
-
+        metrics['total_response_time'] += (time.time() - start)
+        return jsonify(resp)
     except Exception as e:
         metrics['total_response_time'] += (time.time() - start)
         return jsonify({'error': str(e)}), 500

--- a/src/__tests__/opLabAPI.test.js
+++ b/src/__tests__/opLabAPI.test.js
@@ -6,6 +6,7 @@ import {
   API_ENDPOINTS,
   updateRefreshInterval,
   getOpLabService,
+  __resetOpLabService,
   ScreeningUtils
 } from '../opLabAPI'
 
@@ -24,14 +25,17 @@ describe('OpLabAPIService', () => {
   let service
 
   beforeEach(() => {
-    API_CONFIG.baseURL = '/api'
+    API_CONFIG.baseURL = 'https://api.oplab.com.br/v3'
+    API_CONFIG.retryAttempts = 1
+    API_CONFIG.retryDelay = 0
     service = new OpLabAPIService('test-token')
-    mockFetch.mockClear()
+    mockFetch.mockReset()
     vi.clearAllTimers()
     vi.useFakeTimers()
   })
 
   afterEach(() => {
+    vi.useFakeTimers()
     vi.runOnlyPendingTimers()
     vi.useRealTimers()
   })
@@ -140,7 +144,7 @@ describe('OpLabAPIService', () => {
 
       expect(result).toEqual(responseData)
       expect(mockFetch).toHaveBeenCalledWith(
-        '/api/test',
+        'https://api.oplab.com.br/v3/test',
         expect.objectContaining({
           method: 'GET',
           headers: expect.objectContaining({
@@ -184,6 +188,7 @@ describe('OpLabAPIService', () => {
 
     it('should retry on server errors', async () => {
       vi.useRealTimers()
+      API_CONFIG.retryAttempts = 2
       mockFetch
         .mockResolvedValueOnce(
           createMockResponse(
@@ -216,9 +221,11 @@ describe('OpLabAPIService', () => {
     })
 
     it('should handle timeout', async () => {
-      vi.useRealTimers()
-      mockFetch.mockImplementation(() =>
-        new Promise((resolve) => {
+      mockFetch.mockImplementation((_, options) =>
+        new Promise((resolve, reject) => {
+          options.signal.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError'))
+          )
           setTimeout(() => resolve({
             ok: true,
             json: () => Promise.resolve({ data: 'late' }),
@@ -227,10 +234,14 @@ describe('OpLabAPIService', () => {
         })
       )
 
-      await expect(service.executeRequest({
+      const promise = service.executeRequest({
         endpoint: '/test',
         options: { method: 'GET' }
-      })).rejects.toThrow()
+      })
+
+      vi.advanceTimersByTime(API_CONFIG.timeout + 1000)
+
+      await expect(promise).rejects.toThrow()
     })
   })
 
@@ -243,7 +254,7 @@ describe('OpLabAPIService', () => {
 
       expect(result).toEqual(mockData)
       expect(mockFetch).toHaveBeenCalledWith(
-        '/api/instruments',
+        'https://api.oplab.com.br/v3/market/instruments',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ sector: 'Oil' })
@@ -259,7 +270,7 @@ describe('OpLabAPIService', () => {
 
       expect(result).toEqual(mockData)
       expect(mockFetch).toHaveBeenCalledWith(
-        '/api/quotes',
+        'https://api.oplab.com.br/v3/market/quote',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ symbols: ['PETR4', 'VALE3'] })
@@ -274,7 +285,7 @@ describe('OpLabAPIService', () => {
       const result = await service.getFundamentals('PETR4')
 
       expect(result).toEqual(mockData)
-      expect(mockFetch).toHaveBeenCalledWith('/api/fundamentals/PETR4', expect.any(Object))
+      expect(mockFetch).toHaveBeenCalledWith('https://api.oplab.com.br/v3/market/fundamentals/PETR4', expect.any(Object))
     })
 
     it('should check health', async () => {
@@ -284,7 +295,7 @@ describe('OpLabAPIService', () => {
       const result = await service.checkHealth()
 
       expect(result).toEqual(mockData)
-      expect(mockFetch).toHaveBeenCalledWith('/api/health', expect.any(Object))
+      expect(mockFetch).toHaveBeenCalledWith('https://api.oplab.com.br/v3/health', expect.any(Object))
     })
 
     it('should get user info', async () => {
@@ -294,7 +305,7 @@ describe('OpLabAPIService', () => {
       const result = await service.getUserInfo()
 
       expect(result).toEqual(mockData)
-      expect(mockFetch).toHaveBeenCalledWith('/api/user', expect.any(Object))
+      expect(mockFetch).toHaveBeenCalledWith('https://api.oplab.com.br/v3/user', expect.any(Object))
     })
   })
 
@@ -307,9 +318,9 @@ describe('OpLabAPIService', () => {
       const mockQuotes = [
         { symbol: 'PETR4', price: 32.45, volume: 1000000 }
       ]
-      const mockFundamentals = [
-        { symbol: 'PETR4', roic: 8.2, roe: 12, debtToEquity: 0.4 }
-      ]
+      const mockFundamentals = {
+        symbol: 'PETR4', roic: 8.2, roe: 12, debtToEquity: 0.4
+      }
 
       mockFetch
         .mockResolvedValueOnce(createMockResponse(mockInstruments))
@@ -364,7 +375,10 @@ describe('OpLabAPIService', () => {
         fundamental: { roic: 15, roe: 18, debtToEquity: 0.3, revenueGrowth: 0.15 }
       }
 
-      const score = service.calculateWheelScore(stock, { minVolume: 100000 })
+      const score = service.calculateWheelScore({
+        ...stock,
+        filters: { minVolume: 100000 }
+      })
 
       expect(score).toBeGreaterThan(50)
       expect(score).toBeLessThanOrEqual(100)
@@ -377,7 +391,10 @@ describe('OpLabAPIService', () => {
         fundamental: {}
       }
 
-      const score = service.calculateWheelScore(stock, { minVolume: 100000 })
+      const score = service.calculateWheelScore({
+        ...stock,
+        filters: { minVolume: 100000 }
+      })
 
       expect(score).toBeGreaterThan(0)
       expect(score).toBeLessThanOrEqual(100)
@@ -498,9 +515,7 @@ describe('OpLabAPIError', () => {
 
 describe('Default Service Instance', () => {
   afterEach(() => {
-    // Reset the default service
-    const module = require('../opLabAPI')
-    module.defaultService = null
+    __resetOpLabService()
   })
 
   it('should create default service instance', () => {

--- a/src/hooks/useOpLabAPI.js
+++ b/src/hooks/useOpLabAPI.js
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 
 // Base URL for OpLab API (can be overridden via environment variable)
-const API_BASE_URL = import.meta.env.VITE_OPLAB_API_URL || '/api'
+const API_BASE_URL =
+  import.meta.env.VITE_OPLAB_API_URL || 'https://api.oplab.com.br/v3'
 
 // Basic in-memory users for simple authentication
 const VALID_USERS = {

--- a/src/services/opLabAPI.js
+++ b/src/services/opLabAPI.js
@@ -2,8 +2,9 @@
 
 // API Configuration
 export const API_CONFIG = {
-  // Base URL now defaults to local proxy but can be overridden for production
-  baseURL: import.meta?.env?.VITE_OPLAB_API_URL || '/api',
+  // Base URL now points to OpLab's v3 API but can be overridden
+  baseURL: import.meta?.env?.VITE_OPLAB_API_URL ||
+    'https://api.oplab.com.br/v3',
   timeout: 30000,
   retryAttempts: 3,
   retryDelay: 1000,
@@ -553,8 +554,13 @@ export function getOpLabService(token = null) {
   } else if (token) {
     defaultService.setToken(token)
   }
-  
+
   return defaultService
+}
+
+// Internal helper for tests to reset the singleton instance
+export function __resetOpLabService() {
+  defaultService = null
 }
 
 // Utility functions for screening filters


### PR DESCRIPTION
## Summary
- point client and hooks to OpLab API v3
- adjust API tests for new endpoints and add reset helper
- fix backend fundamentals response

## Testing
- `npx vitest run src/__tests__/opLabAPI.test.js`
- `pytest`
- `npm test` *(fails: Cannot find module '@/hooks/useOpLabAPI' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a56a8bfe3883299e997ab3c26e71e8